### PR TITLE
Fix overly-specific regex

### DIFF
--- a/trunk/includes/pardot-plugin-class.php
+++ b/trunk/includes/pardot-plugin-class.php
@@ -632,7 +632,7 @@ class Pardot_Plugin {
 						/**
 						 * Look for URLs in the embed code
 						 */
-						$reg_exUrl = "/(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\/\S*)?/";
+						$reg_exUrl = "/(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+(\/\S*)?/";
 						preg_match( $reg_exUrl, $form_html, $url );
 						/**
 						 * Replace whatever is there with the approved Pardot HTTPS URL


### PR DESCRIPTION
The previous regex only matches domains that end in 2 or 3 characters. These days lots of domains don't end in 2 or 3 chars. This regex fixes that.