### PR TITLE
Fix for the for-condition when requesting forms

### DIFF
--- a/trunk/includes/pardot-api-class.php
+++ b/trunk/includes/pardot-api-class.php
@@ -251,7 +251,8 @@ class Pardot_API {
 				$numpag = round($response->result->total_results/200)+1;
 				for( $j = 2; $j <= ($numpag); $j++ ) {
 					if ( $response = $this->get_response( 'form', $args, 'result', $j ) ) {
-						for( $i = 0; $i < ($response->result->total_results-200); $i++ ) {
+						$count = count($response->result->form);
+						for( $i = 0; $i < $count; $i++ ) {
 							$form = $response->result->form[$i];
 							$forms[(int)$form->id] = $this->SimpleXMLElement_to_stdClass( $form );
 						}


### PR DESCRIPTION
Iterating over the `$total_results - 200` causes `$i` to be
- too high if `$total_results` exceeds 400
- too low if `$total_results` undercuts 200 (untested, perhaps something
  prevents this)

Counting the forms prevents this.