### PR TITLE
Do not pre-fill password in settings

### DIFF
--- a/trunk/includes/pardot-settings-class.php
+++ b/trunk/includes/pardot-settings-class.php
@@ -390,6 +390,13 @@ HTML;
 		}
 
 		/**
+		 * Use existing password if the setting has not been changed
+		 */
+		if (empty($dirty['password'])) {
+			$dirty['password'] = self::get_setting( 'password' );
+		}
+
+		/**
 		 * Sanitize each of the fields values
 		 */
 		foreach( $clean as $name => $value ) {
@@ -689,11 +696,22 @@ HTML;
 	 * @since 1.0.0
 	 */
 	function password_field() {
-		$password  = self::get_setting( 'password' );
+		/**
+		 * Grab the length of the real password and turn it into a placeholder string that looks like it is filled
+		 * in whenever a password is set.
+		 */
+		$passwordLength = strlen(self::get_setting( 'password' ));
+		/**
+		 * Set password length to some arbitrary amount iff there is a set password already so that it shows that the
+		 * password is set already without disclosing the exact number of characters in the password
+		 */
+		$passwordLength = $passwordLength > 0 ? 11 : 0;
+		$passwordPlaceholder = str_repeat("&#9679;", $passwordLength);
+
 		$html_name = $this->_get_html_name( 'password' );
 $html =<<<HTML
 <div id="password-wrap">
-	<input type="password" size="30" id="password" name="{$html_name}" value="{$password}" />
+	<input type="password" size="30" id="password" name="{$html_name}" placeholder="{$passwordPlaceholder}" />
 </div>
 HTML;
 		echo $html;


### PR DESCRIPTION
This fixes the security issue on the settings page which pre-populates the password setting, the value of the password is hidden in the ui but can be inspected in any browser to view the plain-text password. The fix is to not populate the password field when changing the settings, the password field is only used for updating the password. If left blank the existing password is used during the Pardot authentication process.

This is what the password field looks like when you go to the Pardot settings page and there is a password already set (the placeholder is always 11 characters):

![https://p197.p4.n0.cdn.getcloudapp.com/items/v1uyPRQR/Screen+Recording+2019-11-05+at+08.50+AM.gif](https://p197.p4.n0.cdn.getcloudapp.com/items/v1uyPRQR/Screen+Recording+2019-11-05+at+08.50+AM.gif)

If there is no password set then there will be no placeholder so the field appears to be empty.