### PR TITLE
fix for http/s and multisite support

### DIFF
--- a/trunk/includes/pardot-settings-class.php
+++ b/trunk/includes/pardot-settings-class.php
@@ -451,7 +451,7 @@ HTML;
                 'code' => $_GET['code'],
                 'client_id' => self::get_setting('client_id'),
                 'client_secret' => self::decrypt_or_original(self::get_setting('client_secret')),
-                'redirect_uri' => 'https://'.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF'],
+                'redirect_uri' => admin_url( 'options-general.php?page=pardot' ),
                 'code_verifier' => get_option(self::$CODE_VERIFIER),
             );
 


### PR DESCRIPTION
This change uses the admin_url() function to reliably pull the correct redirect_uri:

https://developer.wordpress.org/reference/functions/admin_url/