### PR TITLE
Update "Tested up to" plugin header field to 6.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .svn/
-
 *.db
-
 .idea/*
+*.zip

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ add_filter( 'pardot_https_regex', 'pardot_custom_filter_https_regex' );
 
 ## Changelog
 
+### 1.5.8
+
+* Maintenance - Updated "Tested up to" header field to 6.1.1. While this plugin does not have a custom block, [the shortcodes](https://wordpress.org/plugins/pardot/#how%20can%20i%20use%20the%20shortcodes%20without%20the%20visual%20editor%3F) still work as expected.
+* Maintenance - Updated plugin URI.
+* Maintenance - Removed old developer link.
+* Maintenance - Added plugin contributors (if a valid WP.org profile was found).
+
 ### 1.5.7
 * Fix - Allow custom HTTPS tracker domains
 * Fix - Campaign dropdown now appears immediately after authentication

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -1,5 +1,5 @@
 === Pardot ===
-Contributors: Pardot
+Contributors: cliffseal, mikeschinkel, barryhughes, bgoewert
 Donate link: https://salesforce.com
 Tags: pardot, salesforce, marketing automation, forms, dynamic content, tracking, web tracking, account engagement, marketing cloud
 Requires at least: 5.5

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -3,7 +3,7 @@ Contributors: cliffseal, mikeschinkel, barryhughes, bgoewert
 Donate link: https://salesforce.com
 Tags: pardot, salesforce, marketing automation, forms, dynamic content, tracking, web tracking, account engagement, marketing cloud
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 6.1.1
 Stable tag: 1.5.7
 Requires PHP: 7.0
 License: GPLv2 or later

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -4,7 +4,7 @@ Donate link: https://salesforce.com
 Tags: pardot, salesforce, marketing automation, forms, dynamic content, tracking, web tracking, account engagement, marketing cloud
 Requires at least: 5.5
 Tested up to: 6.1.1
-Stable tag: 1.5.7
+Stable tag: 1.5.8
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -41,6 +41,7 @@ In order to use Salesforce SSO authentication, you **must** create a connected a
 1. When the page reloads, click "Authenticate with Salesforce". Enter your Salesforce credentials in the popup that appears. 
 
 You should then see Authentication Status change from "Not Authenticated" to "Authenticated".
+
 = How can I use the shortcodes without the Visual Editor? =
 
 Two simple shortcodes are available for use.
@@ -158,6 +159,13 @@ Filter the regular expression used to find URLs to be converted to https://go.pa
 
 == Changelog ==
 
+= 1.5.8 =
+
+* Maintenance - Updated "Tested up to" header field to 6.1.1. While this plugin does not have a custom block, [the shortcodes](https://wordpress.org/plugins/pardot/#how%20can%20i%20use%20the%20shortcodes%20without%20the%20visual%20editor%3F) still work as expected.
+* Maintenance - Updated plugin URI.
+* Maintenance - Removed old developer link.
+* Maintenance - Added plugin contributors (if a valid WP.org profile was found).
+
 = 1.5.7 =
 
 * Fix - Allow custom HTTPS tracker domains
@@ -171,7 +179,7 @@ Filter the regular expression used to find URLs to be converted to https://go.pa
 
 = 1.5.5 =
 
-* Fix - Allow retrieving more than 200 assets when authing via Salesforce SSO
+* Fix - Allow retrieving more than 200 assets when authenticating via Salesforce SSO
 
 = 1.5.4 =
 
@@ -379,6 +387,13 @@ Filter the regular expression used to find URLs to be converted to https://go.pa
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.5.8 =
+
+* Maintenance - Updated "Tested up to" header field to 6.1.1. While this plugin does not have a custom block, [the shortcodes](https://wordpress.org/plugins/pardot/#how%20can%20i%20use%20the%20shortcodes%20without%20the%20visual%20editor%3F) still work as expected.
+* Maintenance - Updated plugin URI.
+* Maintenance - Removed old developer link.
+* Maintenance - Added plugin contributors (if a valid WP.org profile was found).
 
 = 1.5.7 =
 

--- a/trunk/includes/pardot-plugin-class.php
+++ b/trunk/includes/pardot-plugin-class.php
@@ -456,8 +456,6 @@ class Pardot_Plugin
 		 */
 		if ('plugins.php' == $pagenow) {
 			add_filter('plugin_action_links_pardot/pardot.php', [$this, 'plugin_action_links']);
-			add_filter('plugin_row_meta', [$this, 'plugin_row_meta'], 10, 2);
-
 		}
 
 		/**
@@ -511,24 +509,6 @@ class Pardot_Plugin
 		 */
 		array_unshift($actions, Pardot_Settings::get_admin_page_link());
 		return $actions;
-	}
-
-	/**
-	 * Filter hook to add a new link under the plugin description.
-	 *
-	 * @param array $plugin_meta List of HTML links.
-	 * @param string $plugin_file slug for the plugin
-	 * @return array Filtered HTML links for the plugin page for this plugin.
-	 *
-	 * @since 1.0.0
-	 */
-	function plugin_row_meta($plugin_meta, $plugin_file)
-	{
-		if (false !== strpos($plugin_file, '/pardot.php')) {
-			$link_text = __("Visit developer's site", 'pardot');
-			$plugin_meta[] = "<a href=\"http://about.me/mikeschinkel\" target=\"_blank\">{$link_text}</a>";
-		}
-		return $plugin_meta;
 	}
 
 	/**

--- a/trunk/pardot.php
+++ b/trunk/pardot.php
@@ -7,7 +7,7 @@
  * Plugin URI: https://wordpress.org/plugins/pardot/
  * Developer: Salesforce
  * Developer URI: https://www.salesforce.com/products/marketing-cloud/marketing-automation/
- * Version: 1.5.7
+ * Version: 1.5.8
  * License: GPLv2
  *
  * Copyright 2022 Salesforce, Inc.
@@ -29,7 +29,7 @@
 
 define( 'PARDOT_PLUGIN_FILE', __FILE__ );
 define( 'PARDOT_PLUGIN_DIR', dirname( __FILE__ ) );
-define( 'PARDOT_PLUGIN_VER', '1.5.7' );
+define( 'PARDOT_PLUGIN_VER', '1.5.8' );
 
 if ( ! defined( 'PARDOT_FORM_INCLUDE_TYPE' ) ) {
 	define( 'PARDOT_FORM_INCLUDE_TYPE', 'iframe' );	// iframe or inline

--- a/trunk/pardot.php
+++ b/trunk/pardot.php
@@ -4,7 +4,7 @@
  * Description: Connect your WordPress to Pardot with shortcode and widgets for campaign tracking, quick form access, and dynamic content.
  * Author: Salesforce
  * Author URI: https://www.salesforce.com/products/marketing-cloud/marketing-automation/
- * Plugin URI: http://wordpress.org/extend/plugins/pardot/
+ * Plugin URI: https://wordpress.org/plugins/pardot/
  * Developer: Salesforce
  * Developer URI: https://www.salesforce.com/products/marketing-cloud/marketing-automation/
  * Version: 1.5.7


### PR DESCRIPTION
### 1.5.8

* Maintenance - Updated "Tested up to" header field to 6.1.1. While this plugin does not have a custom block, [the shortcodes](https://wordpress.org/plugins/pardot/#how%20can%20i%20use%20the%20shortcodes%20without%20the%20visual%20editor%3F) still work as expected.
* Maintenance - Updated plugin URI.
* Maintenance - Removed old developer link.
* Maintenance - Added plugin contributors (if a valid WP.org profile was found).