### PR TITLE
Handle arrays not to be endlessly long

### DIFF
--- a/trunk/includes/pardot-plugin-class.php
+++ b/trunk/includes/pardot-plugin-class.php
@@ -1216,7 +1216,7 @@ class Pardot_Plugin
 
 		if (empty($saved_trans)) {
 			$saved_trans = [$key];
-		} else {
+		} elseif ( ! in_array($key, $saved_trans) ) { // Only add non-existing keys to array
 			$saved_trans[] = $key;
 		}
 
@@ -1239,7 +1239,7 @@ class Pardot_Plugin
 
 		if (empty($saved_keys)) {
 			$saved_keys = [$key];
-		} else {
+		} elseif( ! in_array($key, $saved_keys) ) { // Only add non-existing keys to array
 			$saved_keys[] = $key;
 		}
 


### PR DESCRIPTION
When not checking the array, if it already contains the key, it can become so long, it can break the database.

We had a database where the array became 350.000+ items - all with the same key.

This fix, makes sure that no duplicate keys is stored.
<img width="679" alt="image" src="https://user-images.githubusercontent.com/31649178/214068595-5a58b1cb-3397-43a2-a4b5-3fc552aac6ad.png">
