### PR TITLE
fix: arguments to search property inside get_response function doesn't work

### DIFF
--- a/trunk/includes/pardot-api-class.php
+++ b/trunk/includes/pardot-api-class.php
@@ -476,9 +476,9 @@ class Pardot_API
 			'Pardot-Business-Unit-Id' => $this->business_unit_id,
 		];
 
-		$body = [
+		$body = array_merge([
 			'offset' => $paged > 1 ? ($paged - 1) * 200 : 0,
-		];
+		], $args);
 
 		$http_response = wp_remote_post(
 			$this->_get_url($item_type, $args),


### PR DESCRIPTION
## Contact person
@yaroslav-borodii

## Description
**Priority:** Low
**Severity:** Tiny

**Description:** according to `Pardot_API->get_response()` function, argument `$args` is `query arguments (but might contain ignored auth arguments)`. I tried to make custom call inside my WordPress theme using this function, but I was wondered when it returned me all prospects with all fields.

**Expected Result:** I can use `Pardot_API->get_response()` function with custom query arguments.

**Actual Result:** When I use custom query arguments, it returns me all the prospects with all fields.

**Steps:**
1. Try to call function with custom arguments
```php
Pardot_API->get_response(
	'prospect',
	[
		'fields'  => 'email',
	]
);
```
2. Check the output
![image](https://github.com/pardot/marketing-cloud-account-engagement-for-wordpress/assets/64497493/502cf6e5-db7f-4714-8758-ad472fe399dc)
3. Integrate my solution
4. Try query again
5. Check the output
![image](https://github.com/pardot/marketing-cloud-account-engagement-for-wordpress/assets/64497493/acc37d38-d6af-4f38-baa2-21707e6ef283)


**Additional information:**
Because of this bug, my code executes **~1000** API Calls to Pardot.
I would be grateful if you can fix it as soon as possible
